### PR TITLE
add an install target for Linux and Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+COMMENT= an experimental project that allows you connect to Azure Cloud Shell from a local terminal without a browser.
+	
+BINDIR=	/usr/local/sbin
+UNAME:=	$(shell uname)
+
 all: build-linux build-darwin build-windows
 
 build-linux:
@@ -8,6 +13,13 @@ build-darwin:
 
 build-windows:
 	GOARCH=amd64 GOOS=windows go build -o bin/windows/amd64/azshell.exe .
+
+install:
+ifeq ($(UNAME), Linux)
+	install -o root -g bin bin/linux/amd64/azshell $(BINDIR)
+else ifeq ($(UNAME), Darwin)
+	install -o root -g bin bin/darwin/amd64/azshell $(BINDIR)
+endif
 
 clean:
 	rm -rf dist/


### PR DESCRIPTION
Hi -

This adds an install target for Linux and Darwin. Tested on MacOS High Sierra and Ubuntu 18.04.