### PR TITLE
Add chocolatey package installation method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ curl https://github.com/yangl900/azshell/releases/download/v0.2.2/azshell_window
 ```
 And unzip the file, the only binary needed is `azshell.exe`.
 
+For Windows (Using [Chocolatey](https://chocolatey.org/packages/azshell) package manager)
+```batch
+choco install azshell
+```
+
 For MacOS:
 ```bash
 curl -sL https://github.com/yangl900/azshell/releases/download/v0.2.2/azshell_macOS_64-bit.tar.gz | tar xz


### PR DESCRIPTION
I've packaged azshell as a chocolatey package : https://chocolatey.org/packages/azshell
If you don't know chocolatey, it's a package management method like apt in debian/ubuntu that allow to easily install/upgrade packages on computer.
I've leveraged AU script and CI/CD to daily check if new version of azshell are available and automatically package the new release !